### PR TITLE
feat: BusSeatMission 배경 흔들림 효과 추가

### DIFF
--- a/RiceCake/RiceCake/BusSeatMission/BusSeatMissionScene.swift
+++ b/RiceCake/RiceCake/BusSeatMission/BusSeatMissionScene.swift
@@ -46,9 +46,17 @@ class BusSeatMissionScene: SKScene, UIGestureRecognizerDelegate {
 extension BusSeatMissionScene {
     //
     func drawBackground() {
-        busSeatMissionBackground.size = CGSize(width: self.size.width, height: self.size.height)
+        busSeatMissionBackground.size = CGSize(width: self.size.width + 4, height: self.size.height + 4)
         busSeatMissionBackground.position = CGPoint(x: self.size.width / 2, y: self.size.height / 2)
         busSeatMissionBackground.zPosition = BusSeatMissionLayer.busSeatMissionBackground
+        
+        // 흔들림 효과 추가
+        let shakeLeft = SKAction.move(to: CGPoint(x: (self.size.width / 2) - 2, y: (self.size.height / 2) - 2), duration: 0.4)
+        let shakeRight = SKAction.move(to: CGPoint(x: (self.size.width / 2) + 2, y: (self.size.height / 2) + 2), duration: 0.4)
+        let shakeBackground = SKAction.sequence([shakeLeft, shakeRight])
+        busSeatMissionBackground.run(SKAction.repeatForever(shakeBackground))
+        
+        // add to Scene
         self.addChild(busSeatMissionBackground)
     }
     //


### PR DESCRIPTION
## 작업 내용

- BusSeatMission의 배경 Node을 대각선으로 흔들리게 만들었습니다.
- 배경 사이즈를 조금 확대해서 프레임을 넘어가지 않도록 했습니다.

https://user-images.githubusercontent.com/102859746/179735731-18b8d4ce-3c98-48a6-afc7-29d4a1146c6c.mov

## 리뷰 포인트

- SpriteKit에서 노드에 Action을 주는 방법을 다른 미션에도 사용할 수 있을 것 같아요.
- Special thanks to Neis :octocat: 

## 다음으로 진행될 작업

- [x] GameView에서 아이가 도로로 튕겨나가는(!!) 버그가 있습니다. 네이스랑 같이 해결해볼게요.

## 질문

- 
